### PR TITLE
Password should be invisible to the accessibility services

### DIFF
--- a/app/src/main/res/layout/sign_in.xml
+++ b/app/src/main/res/layout/sign_in.xml
@@ -38,6 +38,7 @@
             android:layout_height="wrap_content"
             android:layout_margin="15dp"
             android:hint="Enter password"
+            android:importantForAccessibility="no"
             android:inputType="textPassword" />
 
         <Button

--- a/app/src/main/res/layout/sign_up.xml
+++ b/app/src/main/res/layout/sign_up.xml
@@ -41,6 +41,7 @@
         tools:layout_editor_absoluteY="294dp"
         android:layout_marginBottom="21dp"
         android:layout_above="@+id/createButton"
+        android:importantForAccessibility="no"
         android:layout_alignStart="@+id/passField" />
     <EditText
         android:id="@+id/passField"
@@ -51,6 +52,7 @@
         android:hint="Password"
         tools:layout_editor_absoluteX="85dp"
         tools:layout_editor_absoluteY="234dp"
+        android:importantForAccessibility="no"
         android:layout_above="@+id/comfirmPassField"
         android:layout_alignStart="@+id/emailField" />
     <EditText


### PR DESCRIPTION
Due to recent attacks, malicious apps that are using the accessibility service, can capture all user inputs. In this case, password, should be ignored for the accessibility service, so such attacks can not be happened.